### PR TITLE
Remove syntax error in `rbs` file

### DIFF
--- a/sig/booleans.rbs
+++ b/sig/booleans.rbs
@@ -3,5 +3,3 @@ module Booleans
 
   def to_bool: () -> bool
 end
-
-def Boolean: (boolish) -> bool


### PR DESCRIPTION
The library crashes Solargraph because of the syntax error in the `booleans.rbs` file, so I deleted the problematic line.